### PR TITLE
Fix yaml-v2 import path

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/v2/yaml"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Marshals the object into JSON then converts JSON to YAML and returns the


### PR DESCRIPTION
I'm not sure where the problem lies, but the documented import path for yaml-v2 is gopkg.in/yaml.v2

This fix means that I able to `go get github.com/ghodss/yaml`

Without this fix, I get this error:
`package gopkg.in/v2/yaml: unrecognized import path "gopkg.in/v2/yaml"`