### PR TITLE
Fixed some typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ import "github.com/ghodss/yaml"
 Usage is very similar to the JSON library:
 
 ```go
+package main
+
 import (
 	"fmt"
 
@@ -52,7 +54,7 @@ import (
 
 type Person struct {
 	Name string `json:"name"`  // Affects YAML field names too.
-	Age int `json:"name"`
+	Age int `json:"age"`
 }
 
 func main() {
@@ -65,13 +67,13 @@ func main() {
 	}
 	fmt.Println(string(y))
 	/* Output:
-	name: John
 	age: 30
+	name: John
 	*/
 
 	// Unmarshal the YAML back into a Person struct.
 	var p2 Person
-	err := yaml.Unmarshal(y, &p2)
+	err = yaml.Unmarshal(y, &p2)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 		return
@@ -86,6 +88,8 @@ func main() {
 `yaml.YAMLToJSON` and `yaml.JSONToYAML` methods are also available:
 
 ```go
+package main
+
 import (
 	"fmt"
 


### PR DESCRIPTION
Fixed some typos in readme.

1. add `package main`;
2. `name` -> `age`;
3. `:=` -> `=`;
4. correct output.