### PR TITLE
Add a YAMLToJSONPretty function

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -34,7 +34,7 @@ type JSONOpt func(*json.Decoder) *json.Decoder
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 	vo := reflect.ValueOf(o)
-	j, err := yamlToJSON(y, &vo)
+	j, err := yamlToJSON(y, &vo, "", "")
 	if err != nil {
 		return fmt.Errorf("error converting YAML to JSON: %v", err)
 	}
@@ -91,10 +91,14 @@ func JSONToYAML(j []byte) ([]byte, error) {
 //   not use the !!binary tag in your YAML. This will ensure the original base64
 //   encoded data makes it all the way through to the JSON.
 func YAMLToJSON(y []byte) ([]byte, error) {
-	return yamlToJSON(y, nil)
+	return yamlToJSON(y, nil, "", "")
 }
 
-func yamlToJSON(y []byte, jsonTarget *reflect.Value) ([]byte, error) {
+func YAMLToJSONPretty(y []byte) ([]byte, error) {
+	return yamlToJSON(y, nil, "", "  ")
+}
+
+func yamlToJSON(y []byte, jsonTarget *reflect.Value, prefix string, indent string) ([]byte, error) {
 	// Convert the YAML to an object.
 	var yamlObj interface{}
 	err := yaml.Unmarshal(y, &yamlObj)
@@ -112,7 +116,11 @@ func yamlToJSON(y []byte, jsonTarget *reflect.Value) ([]byte, error) {
 	}
 
 	// Convert this object to JSON and return the data.
-	return json.Marshal(jsonObj)
+	if prefix == "" && indent == "" {
+		return json.Marshal(jsonObj)
+	} else {
+		return json.MarshalIndent(jsonObj, prefix, indent)
+	}
 }
 
 func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (interface{}, error) {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -131,6 +131,7 @@ type RunType int
 const (
 	RunTypeJSONToYAML RunType = iota
 	RunTypeYAMLToJSON
+	RunTypeYAMLToJSONPretty
 )
 
 func TestJSONToYAML(t *testing.T) {
@@ -228,6 +229,30 @@ func TestYAMLToJSON(t *testing.T) {
 	runCases(t, RunTypeYAMLToJSON, cases)
 }
 
+func TestYAMLToJSONPretty(t *testing.T) {
+	cases := []Case{
+		{
+			"t: a\n",
+			"{\n  \"t\": \"a\"\n}",
+			nil,
+		}, {
+			"t: \n",
+			"{\n  \"t\": null\n}",
+			strPtr("t: null\n"),
+		}, {
+			"t: null\n",
+			"{\n  \"t\": null\n}",
+			nil,
+		}, {
+			"1: a\n",
+			"{\n  \"1\": \"a\"\n}",
+			strPtr("\"1\": a\n"),
+		},
+	}
+
+	runCases(t, RunTypeYAMLToJSONPretty, cases)
+}
+
 func runCases(t *testing.T, runType RunType, cases []Case) {
 	var f func([]byte) ([]byte, error)
 	var invF func([]byte) ([]byte, error)
@@ -238,10 +263,15 @@ func runCases(t *testing.T, runType RunType, cases []Case) {
 		invF = YAMLToJSON
 		msg = "JSON to YAML"
 		invMsg = "YAML back to JSON"
-	} else {
+	} else if runType == RunTypeYAMLToJSON {
 		f = YAMLToJSON
 		invF = JSONToYAML
 		msg = "YAML to JSON"
+		invMsg = "JSON back to YAML"
+	} else {
+		f = YAMLToJSONPretty
+		invF = JSONToYAML
+		msg = "YAML to JSON pretty"
 		invMsg = "JSON back to YAML"
 	}
 


### PR DESCRIPTION
Right now YAMLToJSON prints the following YAML

```yaml
t: a
```

as `{"t":"a"}`.

YAMLToJSONPretty will print it as

```json
{
  "t": "a"
}
```