### PR TITLE
Add UnmarshalStrict.

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -37,8 +37,8 @@ func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 }
 
 // UnmarshalStrict is like Unmarshal except that any mapping keys that are
-// duplicates, will result in an error.
-// It combines well with the option DisallowUnknownFields.
+// duplicates will result in an error.
+// To also be strict about unknown fields, add the DisallowUnknownFields option.
 func UnmarshalStrict(y []byte, o interface{}, opts ...JSONOpt) error {
 	return unmarshal(yaml.UnmarshalStrict, y, o, opts)
 }

--- a/yaml.go
+++ b/yaml.go
@@ -33,8 +33,19 @@ type JSONOpt func(*json.Decoder) *json.Decoder
 // Unmarshal converts YAML to JSON then uses JSON to unmarshal into an object,
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
+	return unmarshal(yaml.Unmarshal, y, o, opts)
+}
+
+// UnmarshalStrict is like Unmarshal except that any mapping keys that are
+// duplicates, will result in an error.
+// It combines well with the option DisallowUnknownFields.
+func UnmarshalStrict(y []byte, o interface{}, opts ...JSONOpt) error {
+	return unmarshal(yaml.UnmarshalStrict, y, o, opts)
+}
+
+func unmarshal(f func(in []byte, out interface{}) (err error), y []byte, o interface{}, opts []JSONOpt) error {
 	vo := reflect.ValueOf(o)
-	j, err := yamlToJSON(y, &vo, yaml.Unmarshal)
+	j, err := yamlToJSON(y, &vo, f)
 	if err != nil {
 		return fmt.Errorf("error converting YAML to JSON: %v", err)
 	}

--- a/yaml_go110_test.go
+++ b/yaml_go110_test.go
@@ -4,6 +4,8 @@ package yaml
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -32,6 +34,58 @@ func TestUnmarshalWithTags(t *testing.T) {
 		}
 	})
 
+}
+
+// TestUnmarshalStrictWithJSONOpts tests that we return an error if there are
+// duplicate fields in the YAML input.
+func TestUnmarshalStrictWithJSONOpts(t *testing.T) {
+	for _, tc := range []struct {
+		yaml        []byte
+		opts        []JSONOpt
+		want        UnmarshalString
+		wantErr     string
+	}{
+		{
+			// By default, unknown field is ignored.
+			yaml: []byte("a: 1\nunknownField: 2"),
+			want: UnmarshalString{A: "1"},
+		},
+		{
+			// Unknown field produces an error with `DisallowUnknownFields` option.
+			yaml:        []byte("a: 1\nunknownField: 2"),
+			opts:        []JSONOpt{DisallowUnknownFields},
+			wantErr:     `unknown field "unknownField"`,
+		},
+	} {
+		po := prettyFunctionName(tc.opts)
+		s := UnmarshalString{}
+		err := UnmarshalStrict(tc.yaml, &s, tc.opts...)
+		if tc.wantErr != "" && err == nil {
+			t.Errorf("UnmarshalStrict(%#q, &s, %v) = nil; want error", string(tc.yaml), po)
+			continue
+		}
+		if tc.wantErr == "" && err != nil {
+			t.Errorf("UnmarshalStrict(%#q, &s, %#v) = %v; want no error", string(tc.yaml), po, err)
+			continue
+		}
+		// We expect that duplicate fields are discovered during JSON unmarshalling.
+		if want := "error unmarshaling JSON"; tc.wantErr != "" && !strings.Contains(err.Error(), want) {
+			t.Errorf("UnmarshalStrict(%#q, &s, %#v) = %v; want err contains %#q", string(tc.yaml), po, err, want)
+		}
+		if tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("UnmarshalStrict(%#q, &s, %#v) = %v; want err contains %#q", string(tc.yaml), po, err, tc.wantErr)
+		}
+
+		// Only test content of `s` if parsing indicated no error.
+		// If we got an error, `s` may be partially parsed and contain some data.
+		if err != nil {
+			continue
+		}
+
+		if !reflect.DeepEqual(s, tc.want) {
+			t.Errorf("UnmarshalStrict(%#q, &s, %#v) = %+#v; want %+#v", string(tc.yaml), po, s, tc.want)
+		}
+	}
 }
 
 func ExampleUnknown() {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -165,6 +165,7 @@ func prettyFunctionName(opts []JSONOpt) []string {
 }
 
 func unmarshalEqual(t *testing.T, y []byte, s, e interface{}, opts ...JSONOpt) {
+	t.Helper()
 	err := Unmarshal(y, s, opts...)
 	if err != nil {
 		t.Errorf("Unmarshal(%#q, s, %v) = %v", string(y), prettyFunctionName(opts), err)


### PR DESCRIPTION
UnmarshalStrict is like Unmarshal except that any mapping keys that are
duplicates, will result in an error.

Since https://godoc.org/gopkg.in/yaml.v2 provides both Unmarshal and
UnmarshalStrict, this library should provide the same interface.