### PR TITLE
Update Go versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - "1.3"
-  - "1.4"
+  - "1.9"
   - "1.10"
+  - "1.11"
 script:
   - go test
   - go build


### PR DESCRIPTION
* 1.9,  the oldest version which supports t.helper().
* 1.10, the version which was the highest version previously.
* 1.11, the current version.