### PR TITLE
Add basic Go modules support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ghodss/yaml
+
+require gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/yaml.go
+++ b/yaml.go
@@ -1,4 +1,14 @@
-package yaml
+// Package yaml provides a wrapper around go-yaml designed to enable a better
+// way of handling YAML when marshaling to and from structs.
+//
+// In short, this package first converts YAML to JSON using go-yaml and then
+// uses json.Marshal and json.Unmarshal to convert to or from the struct. This
+// means that it effectively reuses the JSON struct tags as well as the custom
+// JSON methods MarshalJSON and UnmarshalJSON unlike go-yaml.
+//
+// See also http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang
+//
+package yaml  // import "github.com/ghodss/yaml"
 
 import (
 	"bytes"


### PR DESCRIPTION
In order to work well with [Go modules](https://github.com/golang/go/wiki/Modules), a package should have a `go.mod` file and semantic version tags on release versions. This repo has the latter (though the last tag is from 2017), but not the former.

Here I have provided a rudimentary `go.mod` file and the `go.sum` resulting from building and testing the repo with `go test -race -cpu=1,2 ./...`

Assuming you accept this change, and if you are willing to also `git tag v1.1.0 master` after it is merged, that would update the release history. I think some of the more recent changes are worth including.