### PR TITLE
Updating go.mod to take the latest release of go-yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
   - "1.9"
   - "1.10"
   - "1.11"
+  - "1.13"
 script:
   - go test
   - go build

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ghodss/yaml
 
-require gopkg.in/yaml.v2 v2.2.2
+require gopkg.in/yaml.v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Updating go-yaml to prevent abuse of high CPU/ memory consumption:
https://github.com/go-yaml/yaml/releases/tag/v2.2.4

Issue where it was mentioned:
https://github.com/kubernetes/kubernetes/issues/83253