### PR TITLE
Upgrade ghodss/yaml to use go-yaml v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/ghodss/yaml
+module github.com/ghodss/yaml/v2
 
-require gopkg.in/yaml.v2 v2.2.2
+go 1.11
+
+require gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yaml.go
+++ b/yaml.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Marshals the object into JSON then converts JSON to YAML and returns the
@@ -44,13 +44,6 @@ type JSONOpt func(*json.Decoder) *json.Decoder
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 	return unmarshal(yaml.Unmarshal, y, o, opts)
-}
-
-// UnmarshalStrict is like Unmarshal except that any mapping keys that are
-// duplicates will result in an error.
-// To also be strict about unknown fields, add the DisallowUnknownFields option.
-func UnmarshalStrict(y []byte, o interface{}, opts ...JSONOpt) error {
-	return unmarshal(yaml.UnmarshalStrict, y, o, opts)
 }
 
 func unmarshal(f func(in []byte, out interface{}) (err error), y []byte, o interface{}, opts []JSONOpt) error {
@@ -115,12 +108,6 @@ func JSONToYAML(j []byte) ([]byte, error) {
 // For strict decoding of YAML, use YAMLToJSONStrict.
 func YAMLToJSON(y []byte) ([]byte, error) {
 	return yamlToJSON(y, nil, yaml.Unmarshal)
-}
-
-// YAMLToJSONStrict is like YAMLToJSON but enables strict YAML decoding,
-// returning an error on any duplicate field names.
-func YAMLToJSONStrict(y []byte) ([]byte, error) {
-	return yamlToJSON(y, nil, yaml.UnmarshalStrict)
 }
 
 func yamlToJSON(y []byte, jsonTarget *reflect.Value, yamlUnmarshal func([]byte, interface{}) error) ([]byte, error) {

--- a/yaml_go110_test.go
+++ b/yaml_go110_test.go
@@ -40,26 +40,26 @@ func TestUnmarshalWithTags(t *testing.T) {
 // duplicate fields in the YAML input.
 func TestUnmarshalStrictWithJSONOpts(t *testing.T) {
 	for _, tc := range []struct {
-		yaml        []byte
-		opts        []JSONOpt
-		want        UnmarshalString
-		wantErr     string
+		yaml    []byte
+		opts    []JSONOpt
+		want    UnmarshalPrimitives
+		wantErr string
 	}{
 		{
 			// By default, unknown field is ignored.
-			yaml: []byte("a: 1\nunknownField: 2"),
-			want: UnmarshalString{A: "1"},
+			yaml: []byte("bool: true\nunknownField: 2"),
+			want: UnmarshalPrimitives{Bool: true},
 		},
 		{
 			// Unknown field produces an error with `DisallowUnknownFields` option.
-			yaml:        []byte("a: 1\nunknownField: 2"),
+			yaml:        []byte("bool: true\nunknownField: 2"),
 			opts:        []JSONOpt{DisallowUnknownFields},
 			wantErr:     `unknown field "unknownField"`,
 		},
 	} {
 		po := prettyFunctionName(tc.opts)
-		s := UnmarshalString{}
-		err := UnmarshalStrict(tc.yaml, &s, tc.opts...)
+		s := UnmarshalPrimitives{}
+		err := Unmarshal(tc.yaml, &s, tc.opts...)
 		if tc.wantErr != "" && err == nil {
 			t.Errorf("UnmarshalStrict(%#q, &s, %v) = nil; want error", string(tc.yaml), po)
 			continue


### PR DESCRIPTION
This is a breaking change because:

- Strict mode is now the default for yaml.v3
- String-valued boolean support has been dropped for YAML 1.2 spec
compliance
- Default indentation changes (we could set to previous value but since
already breaking might make more sense to use base library default)

As such I have appended the /v2 suffix to the github.com/ghodss/yaml
package name.

fixes #61 

One major side-effect of this upgrade (and the one I am after) is that rountrip coding of YAML files does not incinerate comments.

Signed-off-by: Silas Davis <silas@monax.io>