### PR TITLE
Add YAMLToJSONCustom to accept custom unmarshal func

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -8,7 +8,7 @@
 //
 // See also http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang
 //
-package yaml  // import "github.com/ghodss/yaml"
+package yaml // import "github.com/ghodss/yaml"
 
 import (
 	"bytes"
@@ -121,6 +121,12 @@ func YAMLToJSON(y []byte) ([]byte, error) {
 // returning an error on any duplicate field names.
 func YAMLToJSONStrict(y []byte) ([]byte, error) {
 	return yamlToJSON(y, nil, yaml.UnmarshalStrict)
+}
+
+// YAMLToJSONCustom is like YAMLToJSON but uses the passed in function to
+// unmarshal from YAML to an object.
+func YAMLToJSONCustom(y []byte, yamlUnmarshal func([]byte, interface{}) error) ([]byte, error) {
+	return yamlToJSON(y, nil, yamlUnmarshal)
 }
 
 func yamlToJSON(y []byte, jsonTarget *reflect.Value, yamlUnmarshal func([]byte, interface{}) error) ([]byte, error) {


### PR DESCRIPTION
We want to use YAMLToJSON with yaml.v3 and this is the most minimal
change that allows us to use yaml.v3 without breaking the interface of
the rest of the library.

Why v3? Because v3 changed how it treats boolean values:

> YAML 1.1 bools (yes/no, on/off) are supported as long as they are
> being decoded into a typed bool value. Otherwise they behave as a
> string. Booleans in YAML 1.2 are true/false only.
(https://github.com/go-yaml/yaml/blob/v3/README.md#compatibility)